### PR TITLE
Add fields TTL and Retry when enqueuing tasks

### DIFF
--- a/tasque/client.go
+++ b/tasque/client.go
@@ -65,6 +65,8 @@ func (c *Client) Delay(t *Task, delay time.Duration) error {
 		Timeout:   c.enqueueTimeout,
 		Replicate: c.replicationFactor,
 		Delay:     delay,
+		TTL:       t.ttl,
+		Retry:     t.retry,
 	}
 
 	_, err = client.Add(ar)


### PR DESCRIPTION
Fields TTL and Retry are ignored when enqueuing tasks through AddRequest(). Add them back.