### PR TITLE
Fix bugs in tasque worker

### DIFF
--- a/tasque/worker.go
+++ b/tasque/worker.go
@@ -122,7 +122,6 @@ func (w *Worker) Run() {
 
 	for {
 		client, err := w.pool.Get()
-		defer client.Close()
 		if err != nil {
 			log.Println("tasque: could not get client")
 			select {
@@ -132,6 +131,7 @@ func (w *Worker) Run() {
 			}
 
 		}
+		defer client.Close()
 
 		for {
 			select {

--- a/tasque/worker.go
+++ b/tasque/worker.go
@@ -128,6 +128,7 @@ func (w *Worker) Run() {
 			case <-w.stopch:
 				return
 			case <-time.After(100 * time.Millisecond):
+				continue
 			}
 
 		}


### PR DESCRIPTION
1.  If *defer client.Close()* register before *if err != nil {*, panic will occur when disque is unable to access.
1.  *pool.Get()* should retry after interval when *err != nil*